### PR TITLE
Fixed issue with relative paths to js

### DIFF
--- a/themes/hugo-fresh/layouts/partials/single/javascript.html
+++ b/themes/hugo-fresh/layouts/partials/single/javascript.html
@@ -1,5 +1,5 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
 <script src="https://unpkg.com/feather-icons"></script>
-<script src="{{ "../js/fresh.js" | absURL }}"></script>
-<script src="{{ "../js/jquery.panelslider.min.js" | absURL }}"></script>
+<script src="{{ "js/fresh.js" | absURL }}"></script>
+<script src="{{ "js/jquery.panelslider.min.js" | absURL }}"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js"></script>


### PR DESCRIPTION
Some relative paths for `fresh.js` causes past teams' pages to load for ever (while the actual content has already loaded). I changed them to absolute ones, and it fixes the issue.